### PR TITLE
update corenlp output name

### DIFF
--- a/corenlp.sh
+++ b/corenlp.sh
@@ -16,5 +16,5 @@ for FNAME in $PATH/*
 do
     /usr/bin/java -mx2g -cp "$scriptdir/*" edu.stanford.nlp.pipeline.StanfordCoreNLP -annotators tokenize,ssplit,pos,lemma,ner,parse -ssplit.eolonly -tokenize.whitespace true -file $FNAME
     # /usr/bin/java -mx2g -cp "$scriptdir/*" edu.stanford.nlp.pipeline.StanfordCoreNLP -annotators tokenize,ssplit,pos,lemma,ner,parse -file $FNAME
-    /bin/mv $(/usr/bin/basename $FNAME.xml) $PATH/
+    /bin/mv $(/usr/bin/basename $FNAME.out) $FNAME.xml
 done


### PR DESCRIPTION
Update CoreNLP output name to address the concern in #6 

Output filename is still set to be .xml so I don't have to change convert.py