### PR TITLE
handle unicode data

### DIFF
--- a/preprocess/xmlreader.py
+++ b/preprocess/xmlreader.py
@@ -140,6 +140,7 @@ def combineparse2sent(sent, parse):
         item = parse.pop(0)
         parselist[tidx] += (" " + item)
         partialparse = parselist[tidx].replace(' ','')
+        partialparse = partialparse.encode("ascii", "ignore")
         word = tokenlist[tidx].replace(' ','')
         # print word, partialparse
         if (word + ')') in partialparse:
@@ -147,6 +148,7 @@ def combineparse2sent(sent, parse):
     # Attach to sent
     for (tidx, token) in enumerate(sent.tokenlist):
         item = parselist[tidx]
+        item = item.encode("ascii", "ignore")
         sent.tokenlist[tidx].partialparse = item
     return sent
 


### PR DESCRIPTION
Fix error below when passing in unicode data to convert.py:

`Processing file: /scratch/cluster/elisaf/cs388/finalProject/corpus/rstTrees/2000/test/1184_0000.xml
Traceback (most recent call last):
  File "convert.py", line 27, in <module>
    main(rpath=sys.argv[1])
  File "convert.py", line 21, in main
    extract(fxml)
  File "convert.py", line 14, in extract
    writer(sentlist, fconll)
  File "/scratch/cluster/elisaf/cs388/finalProject/code/DPLP/preprocess/xmlreader.py", line 168, in writer
    line = str(sent.idx) + '\t' + str(token.idx) + '\t' + token.word + '\t' + token.lemma + '\t' + str(token.pos) + '\t' + str(token.deptype) + '\t' + str(token.headidx) + '\t' + str(token.nertype) + '\t' + str(token.partialparse) + '\n'
UnicodeEncodeError: 'ascii' codec can't encode character u'\xc3' in position 7: ordinal not in range(128)`